### PR TITLE
Update_NickName브랜치에 memberId를 email로 대체

### DIFF
--- a/src/main/java/toyProject/toyProject01/member/adapter/out/persistence/MemberMapper.java
+++ b/src/main/java/toyProject/toyProject01/member/adapter/out/persistence/MemberMapper.java
@@ -21,8 +21,7 @@ public class MemberMapper {
 
     MemberJpaEntity mapToJpaEntity(Member member) {
         return new MemberJpaEntity(
-
-                member.getEmail()
+                member.getEmail(),
                 member.getPw(),
                 member.getNickname(),
                 member.getAge(),

--- a/src/main/java/toyProject/toyProject01/member/adapter/out/persistence/SpringDataMemberRepository.java
+++ b/src/main/java/toyProject/toyProject01/member/adapter/out/persistence/SpringDataMemberRepository.java
@@ -15,6 +15,6 @@ public interface SpringDataMemberRepository extends JpaRepository <MemberJpaEnti
     Optional<MemberJpaEntity> findByMemberEmail(@Param("email") String email);
 
     @Modifying
-    @Query("update MemberJpaEntity m SET m.nickName = :nickName WHERE m.memberId = :memberId")
-    void updateNickName(@Param("nickName") String nickName, @Param("memberId") String memberId);
+    @Query("update MemberJpaEntity m SET m.nickName = :nickName WHERE m.email = :email")
+    void updateNickName(@Param("nickName") String nickName, @Param("email") String email);
 }

--- a/src/main/java/toyProject/toyProject01/member/application/port/in/command/UpdateCommand.java
+++ b/src/main/java/toyProject/toyProject01/member/application/port/in/command/UpdateCommand.java
@@ -5,7 +5,7 @@ import lombok.Data;
 @Data
 public class UpdateCommand {
 
-    private final String memberId;
+    private final String email;
     private final String nickname;
 
 }

--- a/src/main/java/toyProject/toyProject01/member/application/service/MemberService.java
+++ b/src/main/java/toyProject/toyProject01/member/application/service/MemberService.java
@@ -27,7 +27,6 @@ import java.util.NoSuchElementException;
 
 public class MemberService implements MemberJoinUseCase, MemberLoginUseCase, MemberUpdateUseCase {
 
-
     private final LoadMemberPort loadMemberPort;
     private final SaveMemberPort saveMemberPort;
     private final UpdateMemberPort updateMemberPort;
@@ -79,20 +78,21 @@ public class MemberService implements MemberJoinUseCase, MemberLoginUseCase, Mem
     @Override
     public boolean UpdateNickName(UpdateCommand updateCommand) {
 
-        updateMemberPort.updateNickName(updateCommand.getMemberId(), updateCommand.getNickname());
+        updateMemberPort.updateNickName(updateCommand.getEmail(), updateCommand.getNickname());
 
         log.info("입력된 닉네임: = {}", updateCommand.getNickname());
-        Member findmember = loadMemberPort.loadMemberWithId(updateCommand.getMemberId());
+        Member findmember = loadMemberPort.loadMemberWithEmail(updateCommand.getEmail());
 
-        log.info("변경된 닉네임 = {}" ,findmember.getNickname());
+        log.info("변경된 닉네임 = {}", findmember.getNickname());
 
-        if(findmember.isSameNickName(updateCommand.getNickname())) {
+        if (findmember.isSameNickName(updateCommand.getNickname())) {
             log.info("변경이 완료 됐습니다.");
             return true;
         } else {
             log.info("변경에 문제가 있습니다");
             return false;
-        }      
+        }
+    }
 
     private boolean possibleJoinWithEmail(String email) {
         try {

--- a/src/test/java/toyProject/toyProject01/member/application/service/MemberServiceTest.java
+++ b/src/test/java/toyProject/toyProject01/member/application/service/MemberServiceTest.java
@@ -162,79 +162,19 @@ public class MemberServiceTest {
     }
 
     @Test
-    public void testLogin_Success() {
-        //given
-        JoinCommand joinMember = new JoinCommand(
-                "yumi",
-                "1234",
-                "test",
-                Date.valueOf("1990-01-01"),
-                "tel",
-                "email"
-        );
-
-        memberJoinUseCase.Join(joinMember);
-        LoginCommand loginMember = new LoginCommand("yumi", "1234");
-
-        //when
-        boolean loginResult = memberLoginUseCase.Login(loginMember);
-
-        //then
-        Assertions.assertThat(loginResult).isTrue();
-
-    }
-
-    @Test
-    @DisplayName("id는 일치하지만, pw가 틀릴때")
-    public void testLogin_false_pw() {
-        //given
-        JoinCommand joinMember = new JoinCommand(
-                "yumi",
-                "1234",
-                "test",
-                Date.valueOf("1990-01-01"),
-                "tel",
-                "email"
-        );
-        memberJoinUseCase.Join(joinMember);
-
-        //when
-        LoginCommand loginMember = new LoginCommand("yumi", "78910");
-        boolean loginResult = memberLoginUseCase.Login(loginMember);
-
-        //then
-        Assertions.assertThat(loginResult).isFalse();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 id를 입력했을때")
-    public void testLogin_false_id() {
-        //given
-
-        //when
-        LoginCommand loginMember = new LoginCommand("yumi", "78910");
-        boolean loginResult = memberLoginUseCase.Login(loginMember);
-
-        //then
-        Assertions.assertThat(loginResult).isFalse();
-    }
-
-
-    @Test
     public void testUpdate_Success_nickName() {
         //given
         JoinCommand joinMember = new JoinCommand(
-                "yumi",
+                "email",
                 "1234",
                 "test",
                 Date.valueOf("1990-01-01"),
-                "tel",
-                "email"
+                "tel"
         );
 
         memberJoinUseCase.Join(joinMember);
 
-        UpdateCommand updateCommand = new UpdateCommand("yumi", "coco");
+        UpdateCommand updateCommand = new UpdateCommand("email", "coco");
 
         //when
         boolean result = memberUpdateUseCase.UpdateNickName(updateCommand);


### PR DESCRIPTION
Background
- 회원 식별을 비즈니스를 memberId 대신에 email로 변경하게 되었습니다.  
- login/join기능에는 변경 사항이 적용이 되어있지만 update기능에는 적용이 되어있지 않았습니다.

Changes
- 모든 Update_nickName관련 파일에 memberId를 제거하고 email로 대체했습니다.

TEST
- 이전에 merge했을때 충돌 해결을 했는데, test_login 테스트 부분에서 메서드가 중복으로 남겨져 있는 이슈를 수정했습니다.
- update test부분에도 변경된 email사항을 수정했습니다. 
