### PR TITLE
게시판 생성 시간 로직 변경 및 수정 시간 기록 추가 

### DIFF
--- a/src/main/java/toyProject/toyProject01/ToyProject01Application.java
+++ b/src/main/java/toyProject/toyProject01/ToyProject01Application.java
@@ -2,7 +2,9 @@ package toyProject.toyProject01;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ToyProject01Application {
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/PostApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/PostApiController.java
@@ -41,13 +41,12 @@ public class PostApiController {
                 memberNo,
                 request.getCategoryId(),
                 request.getTitle(),
-                request.getPostContent(),
-                request.getPostDate()
+                request.getPostContent()
         );
 
-        Post postDomain = resisterPostUseCase.registerPost(resisterPostCommand);
+        Post savedPost = resisterPostUseCase.registerPost(resisterPostCommand);
 
-        ResponsePostDto responseDto = ResponseMapper.mapToPostDomain(postDomain);
+        ResponsePostDto responseDto = ResponseMapper.mapToPostDomain(savedPost);
 
         ResultDto<ResponsePostDto> result = new ResultDto<>(200, "게시물 저장 완료", responseDto);
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
@@ -13,7 +13,7 @@ public class ResponseMapper {
                 post.getCategory().getType(),
                 post.getTitle(),
                 post.getPostContent(),
-                post.getPostDate()
+                post.getCreateDateTime()
         );
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResisterPostDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResisterPostDto.java
@@ -11,5 +11,5 @@ public class ResisterPostDto {
     private final Long categoryId;
     private final String title;
     private final String postContent;
-    private final Date postDate;
+
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResponsePostDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResponsePostDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import toyProject.toyProject01.board.domain.Post;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Getter
@@ -15,6 +16,6 @@ public class ResponsePostDto {
     private final String category;
     private final String title;
     private final String content;
-    private final Date date;
+    private final LocalDateTime createDateTime;
 
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -19,13 +19,13 @@ public class PersistenceMapper {
     PostJpaEntity mapToPostJpaEntity(Post post, MemberJpaEntity memberJpaEntity) {
 
         return new PostJpaEntity(
-
                 post.getPostId(),
                 memberJpaEntity,
                 mapToCategoryJpaEntity(post.getCategory()),
                 post.getTitle(),
                 post.getPostContent(),
-                post.getPostDate()
+                post.getCreateDateTime()
+
         );
     }
 
@@ -44,7 +44,8 @@ public class PersistenceMapper {
                 mapToCategoryDomain(postJpaEntity.getCategory()),
                 postJpaEntity.getTitle(),
                 postJpaEntity.getPostContent(),
-                postJpaEntity.getPostDate()
+                postJpaEntity.getCreateDateTime()
+
         );
     }
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -19,6 +19,7 @@ public class PersistenceMapper {
     PostJpaEntity mapToPostJpaEntity(Post post, MemberJpaEntity memberJpaEntity) {
 
         return new PostJpaEntity(
+
                 post.getPostId(),
                 memberJpaEntity,
                 mapToCategoryJpaEntity(post.getCategory()),
@@ -31,8 +32,7 @@ public class PersistenceMapper {
     //Domain -> JpaEntity
     CategoryJpaEntity mapToCategoryJpaEntity(Category category) {
         return new CategoryJpaEntity(
-                category.getCategoryId(),
-                category.getType()
+                category.getCategoryId()
         );
     }
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -21,11 +21,10 @@ public class PersistenceMapper {
         return new PostJpaEntity(
                 post.getPostId(),
                 memberJpaEntity,
-                mapToCategoryJpaEntity(post.getCategory()),
                 post.getTitle(),
+                mapToCategoryJpaEntity(post.getCategory()),
                 post.getPostContent(),
                 post.getCreateDateTime()
-
         );
     }
 
@@ -44,8 +43,8 @@ public class PersistenceMapper {
                 mapToCategoryDomain(postJpaEntity.getCategory()),
                 postJpaEntity.getTitle(),
                 postJpaEntity.getPostContent(),
-                postJpaEntity.getCreateDateTime()
-
+                postJpaEntity.getCreateDateTime(),
+                postJpaEntity.getUpdateDateTime()
         );
     }
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
@@ -29,18 +29,17 @@ public class PostPersistenceAdapter implements SavePostPort, LoadPostPort, Updat
 
     private final SpringDataPostRepository postRepository;
     private final PersistenceMapper persistenceMapper;
-    //private final SpringDataMemberRepository memberRepository;  //MemberRepository 의존성 추가
 
     @Override
-    public void savePost(Post post) {
-
-        //MemberJpaEntity memberEntity = memberRepository.findById(post.getMemberNo()).orElseThrow();
+    public Post savePost(Post post) {
 
         MemberJpaEntity memberJpaEntity = new MemberJpaEntity(post.getMemberNo());
 
         PostJpaEntity postJpaEntity = persistenceMapper.mapToPostJpaEntity(post , memberJpaEntity);
 
-        postRepository.save(postJpaEntity);
+        PostJpaEntity savedPost = postRepository.save(postJpaEntity);
+
+        return persistenceMapper.mapToPostDomain(savedPost);
     }
 
     //모든 게시판 데이터 조회후 반환

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
@@ -29,14 +29,16 @@ public class PostPersistenceAdapter implements SavePostPort, LoadPostPort, Updat
 
     private final SpringDataPostRepository postRepository;
     private final PersistenceMapper persistenceMapper;
-    private final SpringDataMemberRepository memberRepository;  //MemberRepository 의존성 추가
+    //private final SpringDataMemberRepository memberRepository;  //MemberRepository 의존성 추가
 
     @Override
     public void savePost(Post post) {
 
-        MemberJpaEntity memberEntity = memberRepository.findById(post.getMemberNo()).orElseThrow();
+        //MemberJpaEntity memberEntity = memberRepository.findById(post.getMemberNo()).orElseThrow();
 
-        PostJpaEntity postJpaEntity = persistenceMapper.mapToPostJpaEntity(post , memberEntity);
+        MemberJpaEntity memberJpaEntity = new MemberJpaEntity(post.getMemberNo());
+
+        PostJpaEntity postJpaEntity = persistenceMapper.mapToPostJpaEntity(post , memberJpaEntity);
 
         postRepository.save(postJpaEntity);
     }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CategoryJpaEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CategoryJpaEntity.java
@@ -19,4 +19,7 @@ public class CategoryJpaEntity {
     private String type;
 
 
+    public CategoryJpaEntity(Long categoryId) {
+        this.categoryId = categoryId;
+    }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/PostJpaEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/PostJpaEntity.java
@@ -4,10 +4,14 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import toyProject.toyProject01.board.domain.Category;
 import toyProject.toyProject01.member.adapter.out.persistence.MemberJpaEntity;
 import toyProject.toyProject01.member.domain.Member;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
@@ -15,6 +19,7 @@ import java.util.Date;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class PostJpaEntity {
 
     @Id
@@ -34,11 +39,14 @@ public class PostJpaEntity {
 
     private String postContent;
 
-    private Date postDate;
+    @CreatedDate
+    private LocalDateTime createDateTime;
 
-    public void update(CategoryJpaEntity category, String title, String postContent) {
+        public void update(CategoryJpaEntity category, String title, String postContent) {
         this.category = category;
         this.title = title;
         this.postContent = postContent;
     }
+
+
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/PostJpaEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/PostJpaEntity.java
@@ -42,10 +42,45 @@ public class PostJpaEntity {
     @CreatedDate
     private LocalDateTime createDateTime;
 
-        public void update(CategoryJpaEntity category, String title, String postContent) {
+    private LocalDateTime updateDateTime;
+
+    @Transient
+    private PostJpaEntity previousState;
+
+    public PostJpaEntity(Long postId,
+                         MemberJpaEntity member,
+                         String title,
+                         CategoryJpaEntity category,
+                         String postContent,
+                         LocalDateTime updateDateTime
+    ) {
+        this.postId = postId;
+        this.member = member;
+        this.title = title;
+        this.category = category;
+        this.postContent = postContent;
+        this.updateDateTime = updateDateTime;
+    }
+
+
+
+    @PostLoad
+    public void setPreviousState() {
+        previousState = new PostJpaEntity();
+        // copy fields
+    }
+
+    public void update(CategoryJpaEntity category, String title, String postContent) {
         this.category = category;
         this.title = title;
         this.postContent = postContent;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        if (!title.equals(previousState.title) || !postContent.equals(previousState.postContent)) {
+            updateDateTime = LocalDateTime.now();
+        }
     }
 
 

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/command/ResisterPostCommand.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/command/ResisterPostCommand.java
@@ -25,15 +25,12 @@ public class ResisterPostCommand extends SelfValidating<ResisterPostCommand> {
     @Size(min = 1, max = 50, message = "내용은 최소 1글자, 최대 50글자를 입력하세요.")
     private final String postContent;
 
-    @NotNull
-    private final Date postDate;
 
-    public ResisterPostCommand(Long memberNo,Long category, String title, String postContent, Date postDate) {
+    public ResisterPostCommand(Long memberNo,Long category, String title, String postContent) {
         this.memberNo = memberNo;
         this.category = category;
         this.title = title;
         this.postContent = postContent;
-        this.postDate = postDate;
 
         this.validateSelf();
     }

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/SavePostPort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/SavePostPort.java
@@ -4,5 +4,5 @@ import toyProject.toyProject01.board.domain.Post;
 
 public interface SavePostPort {
 
-    void savePost(Post post);
+    Post savePost(Post post);
 }

--- a/src/main/java/toyProject/toyProject01/board/application/service/ResisterPostService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/ResisterPostService.java
@@ -50,11 +50,12 @@ public class ResisterPostService implements ResisterPostUseCase, LoadPostUseCase
                 category,
                 resisterPostCommand.getTitle(),
                 resisterPostCommand.getPostContent(),
-                resisterPostCommand.getPostDate()
+                null,
+                null
         );
 
-        savePostPort.savePost(postDomain);
-        return postDomain;
+        return savePostPort.savePost(postDomain);
+
     }
 
     @Override
@@ -82,6 +83,7 @@ public class ResisterPostService implements ResisterPostUseCase, LoadPostUseCase
                 category,
                 updatePostCommand.getTitle(),
                 updatePostCommand.getPostContent(),
+                null,
                 null
         );
 

--- a/src/main/java/toyProject/toyProject01/board/domain/Post.java
+++ b/src/main/java/toyProject/toyProject01/board/domain/Post.java
@@ -16,6 +16,7 @@ public class Post {
     private final Category category;
     private final String title;
     private final String postContent;
-    private final Date postDate;
+    private final LocalDateTime createDateTime;
+    //private final LocalDateTime updateDate;
 
 }

--- a/src/main/java/toyProject/toyProject01/board/domain/Post.java
+++ b/src/main/java/toyProject/toyProject01/board/domain/Post.java
@@ -17,6 +17,6 @@ public class Post {
     private final String title;
     private final String postContent;
     private final LocalDateTime createDateTime;
-    //private final LocalDateTime updateDate;
+    private final LocalDateTime updateDateTime;
 
 }


### PR DESCRIPTION
- 게시판을 등록할때 기존에 클라이언트에서 보내주는 시간을 저장하고 있었는데, 이 로직은 언제든 조작이 가능하기 때문에 서버시간을 저장하는 로직으로 리팩토링을 했습니다.

- 게시판을 수정할때 수정시간에 대한 기록 기능이 없었는데, 수정을 할때 수정 시간을 기록을 해줘야 서비스를 운영할때 사용이 필요한 경우가 있기 때문에 새로 기능을 추가했습니다. 