### PR TITLE
게시글 조회 기능 최적화를 위한 페이징기능 추가 및 응답구조 변경

### DIFF
--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/PostApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/PostApiController.java
@@ -6,13 +6,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
-import toyProject.toyProject01.board.adapter.in.web.dto.ResisterPostDto;
-import toyProject.toyProject01.board.adapter.in.web.dto.ResponsePostDto;
-import toyProject.toyProject01.board.adapter.in.web.dto.UpdatePostDto;
+import toyProject.toyProject01.board.adapter.in.web.dto.*;
 import toyProject.toyProject01.board.application.port.in.DeletePostUseCase;
 import toyProject.toyProject01.board.application.port.in.LoadPostUseCase;
 import toyProject.toyProject01.board.application.port.in.ResisterPostUseCase;
 import toyProject.toyProject01.board.application.port.in.UpdatePostUseCase;
+import toyProject.toyProject01.board.application.port.in.command.GetPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.ResisterPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.UpdatePostCommand;
 import toyProject.toyProject01.board.domain.Post;
@@ -55,15 +54,19 @@ public class PostApiController {
 
     //모든 게시물 조회
     @GetMapping("/posts")
-    public ResponseEntity<ResultDto<List<ResponsePostDto>>> findAllPosts() {
+    public ResponseEntity<ResultDto<List<ResponseListPostDto>>> getPosts(
+            @RequestBody RequestPageDto request) {
 
-        //모든 게시물 리스트로 조회
-        //응답Dto타입의 리스트로 변환
-        List<ResponsePostDto> responseDto = loadPostUseCase.findPostAll().stream()
-                .map(ResponseMapper::mapToPostDomain)
+        GetPostCommand getPostCommand =
+                new GetPostCommand(request.getCurrentPage(), request.getSize(), request.getSortType());
+
+        List<ResponseListPostDto> responseDto =
+                loadPostUseCase.getPostList(getPostCommand).stream()
+                .map(ResponseMapper::mapToListPostDto)
                 .collect(Collectors.toList());
 
-        ResultDto<List<ResponsePostDto>> result = new ResultDto<>(200, "게시물 조회 완료", responseDto);
+        ResultDto<List<ResponseListPostDto>> result =
+                new ResultDto<>(200, "게시물 조회 완료", responseDto);
 
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
@@ -1,6 +1,7 @@
 package toyProject.toyProject01.board.adapter.in.web;
 
 import org.springframework.stereotype.Component;
+import toyProject.toyProject01.board.adapter.in.web.dto.ResponseListPostDto;
 import toyProject.toyProject01.board.adapter.in.web.dto.ResponsePostDto;
 import toyProject.toyProject01.board.domain.Post;
 
@@ -9,10 +10,20 @@ public class ResponseMapper {
 
     static ResponsePostDto mapToPostDomain(Post post) {
         return new ResponsePostDto (
-                post.getMemberNo(),
+                post.getMember().getMemberNo(),
                 post.getCategory().getType(),
                 post.getTitle(),
                 post.getPostContent(),
+                post.getCreateDateTime()
+        );
+    }
+
+    static ResponseListPostDto mapToListPostDto(Post post) {
+        return new ResponseListPostDto(
+                post.getPostId(),
+                post.getCategory().getType(),
+                post.getTitle(),
+                post.getMember().getNickName(),
                 post.getCreateDateTime()
         );
     }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/RequestPageDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/RequestPageDto.java
@@ -1,0 +1,14 @@
+package toyProject.toyProject01.board.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RequestPageDto {
+
+    private final int currentPage;
+    private final int size;
+    private final String sortType;
+
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResponseListPostDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResponseListPostDto.java
@@ -1,0 +1,17 @@
+package toyProject.toyProject01.board.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ResponseListPostDto {
+
+    private final Long postID;
+    private final String categoryType;
+    private final String title;
+    private final String nickName;
+    private final LocalDateTime createDateTime;
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -37,14 +37,29 @@ public class PersistenceMapper {
 
     //JpaEntity -> Domain
     Post mapToPostDomain(PostJpaEntity postJpaEntity) {
+
+
+
         return new Post(
                 postJpaEntity.getPostId(),
-                postJpaEntity.getMember().getNo(),
+                new Post.PostMember(postJpaEntity.getMember().getNo(), postJpaEntity.getMember().getNickName()),
                 mapToCategoryDomain(postJpaEntity.getCategory()),
                 postJpaEntity.getTitle(),
                 postJpaEntity.getPostContent(),
                 postJpaEntity.getCreateDateTime(),
                 postJpaEntity.getUpdateDateTime()
+        );
+    }
+
+    //JpaEntity -> Domain
+    Post mapToListPostDomain(PostJpaEntity postJpaEntity) {
+        return new Post(
+                postJpaEntity.getPostId(),
+                new Post.PostMember(postJpaEntity.getMember().getNo(), postJpaEntity.getMember().getNickName()),
+                mapToCategoryDomain(postJpaEntity.getCategory()),
+                postJpaEntity.getTitle(),
+                postJpaEntity.getPostContent(),
+                postJpaEntity.getCreateDateTime()
         );
     }
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
@@ -2,6 +2,9 @@ package toyProject.toyProject01.board.adapter.out.persistence;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.CategoryJpaEntity;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.PostJpaEntity;
@@ -33,7 +36,7 @@ public class PostPersistenceAdapter implements SavePostPort, LoadPostPort, Updat
     @Override
     public Post savePost(Post post) {
 
-        MemberJpaEntity memberJpaEntity = new MemberJpaEntity(post.getMemberNo());
+        MemberJpaEntity memberJpaEntity = new MemberJpaEntity(post.getMember().getMemberNo());
 
         PostJpaEntity postJpaEntity = persistenceMapper.mapToPostJpaEntity(post , memberJpaEntity);
 
@@ -44,12 +47,18 @@ public class PostPersistenceAdapter implements SavePostPort, LoadPostPort, Updat
 
     //모든 게시판 데이터 조회후 반환
     @Override
-    public List<Post> findPostAll() {
-        List<PostJpaEntity> findAllPosts = postRepository.findAll();
+    public List<Post> findPostAll(int currentPage, int size, String sortType) {
 
-        return findAllPosts.stream()
-                .map(persistenceMapper::mapToPostDomain)
-                .collect(Collectors.toList());
+        PageRequest pageRequest =
+                PageRequest.of(
+                currentPage,
+                size,
+                Sort.by(Sort.Direction.ASC, sortType)
+        );
+
+         return postRepository.findAll(pageRequest).stream()
+                 .map(persistenceMapper::mapToListPostDomain)
+                 .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/LoadPostUseCase.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/LoadPostUseCase.java
@@ -1,5 +1,6 @@
 package toyProject.toyProject01.board.application.port.in;
 
+import toyProject.toyProject01.board.application.port.in.command.GetPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.UpdatePostCommand;
 import toyProject.toyProject01.board.domain.Post;
 
@@ -7,7 +8,7 @@ import java.util.List;
 
 public interface LoadPostUseCase {
 
-    List<Post> findPostAll();
+    List<Post> getPostList(GetPostCommand getPostCommand);
 
     Post findPostOne(Long postId);
 }

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/command/GetPostCommand.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/command/GetPostCommand.java
@@ -1,0 +1,27 @@
+package toyProject.toyProject01.board.application.port.in.command;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import toyProject.toyProject01.common.SelfValidating;
+
+@Getter
+public class GetPostCommand extends SelfValidating<ResisterPostCommand> {
+
+    @NotNull
+    private final int currentPage;
+
+    @NotNull
+    private final int size;
+
+    @NotBlank
+    private final String sortType;
+
+    public GetPostCommand(int currentPage, int size, String sortType) {
+        this.currentPage = currentPage;
+        this.size = size;
+        this.sortType = sortType;
+
+        this.validateSelf();
+    }
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/LoadPostPort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/LoadPostPort.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface LoadPostPort {
 
-    List<Post> findPostAll();
+    List<Post> findPostAll(int currentPage, int size, String sortType);
 
     Post findPostId(Long postId);
 }

--- a/src/main/java/toyProject/toyProject01/board/application/service/ResisterPostService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/ResisterPostService.java
@@ -10,6 +10,7 @@ import toyProject.toyProject01.board.application.port.in.DeletePostUseCase;
 import toyProject.toyProject01.board.application.port.in.LoadPostUseCase;
 import toyProject.toyProject01.board.application.port.in.ResisterPostUseCase;
 import toyProject.toyProject01.board.application.port.in.UpdatePostUseCase;
+import toyProject.toyProject01.board.application.port.in.command.GetPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.ResisterPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.UpdatePostCommand;
 import toyProject.toyProject01.board.application.port.out.DeletePostPort;
@@ -46,7 +47,7 @@ public class ResisterPostService implements ResisterPostUseCase, LoadPostUseCase
 
         Post postDomain = new Post(
                 null,
-                resisterPostCommand.getMemberNo(),
+                new Post.PostMember(resisterPostCommand.getMemberNo(), null),
                 category,
                 resisterPostCommand.getTitle(),
                 resisterPostCommand.getPostContent(),
@@ -59,8 +60,13 @@ public class ResisterPostService implements ResisterPostUseCase, LoadPostUseCase
     }
 
     @Override
-    public List<Post> findPostAll() {
-        return loadPostPort.findPostAll();
+    public List<Post> getPostList(GetPostCommand getPostCommand) {
+
+        return loadPostPort.findPostAll(
+                getPostCommand.getCurrentPage(),
+                getPostCommand.getSize(),
+                getPostCommand.getSortType()
+        );
     }
 
     @Override

--- a/src/main/java/toyProject/toyProject01/board/domain/Post.java
+++ b/src/main/java/toyProject/toyProject01/board/domain/Post.java
@@ -12,11 +12,29 @@ import java.util.Date;
 public class Post {
 
     private final Long postId;
-    private final Long memberNo;
+    private final PostMember member;
     private final Category category;
     private final String title;
     private final String postContent;
     private final LocalDateTime createDateTime;
-    private final LocalDateTime updateDateTime;
+    private LocalDateTime updateDateTime;
 
+
+    @Getter
+    @AllArgsConstructor
+    public static class PostMember {
+        private final Long memberNo;
+        private final String nickName;
+    }
+
+    public Post(Long postId, PostMember member, Category category, String title, String postContent, LocalDateTime createDateTime) {
+        this.postId = postId;
+        this.member = member;
+        this.category = category;
+        this.title = title;
+        this.postContent = postContent;
+        this.createDateTime = createDateTime;
+    }
 }
+
+


### PR DESCRIPTION
- 게시글 조회시 저장되어 있는 모든 게시글을 한꺼번에 응답해주고 있어서 많은 데이터가 있을시에는 문제가 생길 수 있었습니다.
그래서 페이징 기능을 사용해서 한꺼번에 조회하는 데이터의 양을 줄이도록 개선했습니다.

- 게시글 조회시 필요없는 데이터들도 함께 응답하도록 되어 있는 문제가 있었습니다. 응답할때 꼭 필요한 데이터만 응답하도록 수정했습니다.
