### PR TITLE
게시글을 여러 상태 타입으로 분류하여 관리 할 수 있는 기능 추가

### DIFF
--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/PostApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/PostApiController.java
@@ -7,10 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import toyProject.toyProject01.board.adapter.in.web.dto.*;
-import toyProject.toyProject01.board.application.port.in.DeletePostUseCase;
-import toyProject.toyProject01.board.application.port.in.LoadPostUseCase;
-import toyProject.toyProject01.board.application.port.in.ResisterPostUseCase;
-import toyProject.toyProject01.board.application.port.in.UpdatePostUseCase;
+import toyProject.toyProject01.board.application.port.in.*;
 import toyProject.toyProject01.board.application.port.in.command.GetPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.ResisterPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.UpdatePostCommand;
@@ -109,12 +106,11 @@ public class PostApiController {
     @DeleteMapping("/posts/{postId}")
     public ResponseEntity<ResultDto<Long>> deletePost(@PathVariable Long postId) {
 
-        //게시글 삭제
-        deletePostUseCase.deletePost(postId);
+        deletePostUseCase.softDeletePost(postId);
 
-        //응답 결과 객체 생성
-        ResultDto<Long> result = new ResultDto<>(200, "해당 게시물 조회 완료", postId);
+        ResultDto<Long> result = new ResultDto<>(200, "해당 게시물 삭제 완료", postId);
 
         return new ResponseEntity<>(result, HttpStatus.CREATED);
     }
+
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/PostApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/PostApiController.java
@@ -110,7 +110,7 @@ public class PostApiController {
 
         ResultDto<Long> result = new ResultDto<>(200, "해당 게시물 삭제 완료", postId);
 
-        return new ResponseEntity<>(result, HttpStatus.CREATED);
+        return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
@@ -92,7 +92,7 @@ public class PostPersistenceAdapter implements
     }
 
     @Override
-    public void delete(Long postId) {
+    public void stateToDelete(Long postId) {
         PostJpaEntity findPostEntity = postRepository.findById(postId)
                 .orElseThrow(() -> new NoSuchElementException("Not Found Post: " + postId));
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
@@ -47,14 +47,14 @@ public class PostPersistenceAdapter implements
                 Sort.by(Sort.Direction.ASC, sortType)
         );
 
-         return postRepository.findAll(pageRequest).stream()
+         return postRepository.getPosts(pageRequest, PostJpaEntity.PostState.ACTIVE).stream()
                  .map(persistenceMapper::mapToListPostDomain)
                  .collect(Collectors.toList());
     }
 
     @Override
     public Post findPostId(Long postId) {
-        PostJpaEntity findPost = postRepository.findById(postId)
+        PostJpaEntity findPost = postRepository.getPostDetail(postId, PostJpaEntity.PostState.ACTIVE)
                 .orElseThrow(() -> new NoSuchElementException("Not Found Post: " + postId));
 
         return persistenceMapper.mapToPostDomain(findPost);

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PostPersistenceAdapter.java
@@ -2,33 +2,24 @@ package toyProject.toyProject01.board.adapter.out.persistence;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.transaction.annotation.Transactional;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.CategoryJpaEntity;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.PostJpaEntity;
-import toyProject.toyProject01.board.application.port.in.command.UpdatePostCommand;
-import toyProject.toyProject01.board.application.port.out.DeletePostPort;
-import toyProject.toyProject01.board.application.port.out.LoadPostPort;
-import toyProject.toyProject01.board.application.port.out.SavePostPort;
-import toyProject.toyProject01.board.application.port.out.UpdatePostPort;
-import toyProject.toyProject01.board.domain.Category;
+import toyProject.toyProject01.board.application.port.out.*;
 import toyProject.toyProject01.board.domain.Post;
 import toyProject.toyProject01.common.PersistenceAdapter;
 import toyProject.toyProject01.member.adapter.out.persistence.MemberJpaEntity;
-import toyProject.toyProject01.member.adapter.out.persistence.SpringDataMemberRepository;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class PostPersistenceAdapter implements SavePostPort, LoadPostPort, UpdatePostPort, DeletePostPort {
+public class PostPersistenceAdapter implements
+        SavePostPort, LoadPostPort, UpdatePostPort, DeletePostPort, ChangePostStatePort {
 
     private final SpringDataPostRepository postRepository;
     private final PersistenceMapper persistenceMapper;
@@ -94,8 +85,17 @@ public class PostPersistenceAdapter implements SavePostPort, LoadPostPort, Updat
         return persistenceMapper.mapToPostDomain(findPostEntity);
     }
 
+
     @Override
     public void deletePost(Long postId) {
         postRepository.deleteById(postId);
+    }
+
+    @Override
+    public void delete(Long postId) {
+        PostJpaEntity findPostEntity = postRepository.findById(postId)
+                .orElseThrow(() -> new NoSuchElementException("Not Found Post: " + postId));
+
+        findPostEntity.setPostState(PostJpaEntity.PostState.DELETE);
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataPostRepository.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataPostRepository.java
@@ -1,7 +1,20 @@
 package toyProject.toyProject01.board.adapter.out.persistence;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.PostJpaEntity;
+import toyProject.toyProject01.member.adapter.out.persistence.MemberJpaEntity;
+
+import java.util.Optional;
 
 public interface SpringDataPostRepository extends JpaRepository<PostJpaEntity, Long> {
+
+    @Query("select p from PostJpaEntity p where p.postState = :postState")
+    Page<PostJpaEntity> getPosts(Pageable pageable, PostJpaEntity.PostState postState);
+
+    @Query("select p from PostJpaEntity p where p.postId = :postId AND p.postState = :postState")
+    Optional<PostJpaEntity> getPostDetail(Long postId, PostJpaEntity.PostState postState);
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/PostJpaEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/PostJpaEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -38,6 +39,9 @@ public class PostJpaEntity {
     private String title;
 
     private String postContent;
+
+    @Enumerated(EnumType.STRING)
+    private PostState postState = PostState.ACTIVE;
 
     @CreatedDate
     private LocalDateTime createDateTime;
@@ -83,5 +87,11 @@ public class PostJpaEntity {
         }
     }
 
+    public enum PostState {
+        ACTIVE,
+        DELETE,
+        HIDE,
+        REVIEW
+    }
 
 }

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/DeletePostUseCase.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/DeletePostUseCase.java
@@ -3,4 +3,6 @@ package toyProject.toyProject01.board.application.port.in;
 public interface DeletePostUseCase {
 
     void deletePost(Long postId);
+
+    void softDeletePost(Long postId);
 }

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/ChangePostStatePort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/ChangePostStatePort.java
@@ -1,0 +1,6 @@
+package toyProject.toyProject01.board.application.port.out;
+
+public interface ChangePostStatePort {
+
+    void delete(Long postId);
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/ChangePostStatePort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/ChangePostStatePort.java
@@ -2,5 +2,5 @@ package toyProject.toyProject01.board.application.port.out;
 
 public interface ChangePostStatePort {
 
-    void delete(Long postId);
+    void stateToDelete(Long postId);
 }

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/DeletePostPort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/DeletePostPort.java
@@ -3,4 +3,5 @@ package toyProject.toyProject01.board.application.port.out;
 public interface DeletePostPort {
 
     void deletePost(Long postId);
+
 }

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/UpdatePostPort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/UpdatePostPort.java
@@ -6,4 +6,5 @@ import toyProject.toyProject01.board.domain.Post;
 public interface UpdatePostPort {
 
     Post updatePost(Long targetId, Post updatePost);
+
 }

--- a/src/main/java/toyProject/toyProject01/board/application/service/ResisterPostService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/ResisterPostService.java
@@ -97,7 +97,7 @@ public class ResisterPostService implements
 
     @Override
     public void softDeletePost(Long postId) {
-        changePostStatePort.delete(postId);
+        changePostStatePort.stateToDelete(postId);
     }
 
 }

--- a/src/main/java/toyProject/toyProject01/board/application/service/ResisterPostService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/ResisterPostService.java
@@ -2,26 +2,17 @@ package toyProject.toyProject01.board.application.service;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import toyProject.toyProject01.board.application.port.in.DeletePostUseCase;
-import toyProject.toyProject01.board.application.port.in.LoadPostUseCase;
-import toyProject.toyProject01.board.application.port.in.ResisterPostUseCase;
-import toyProject.toyProject01.board.application.port.in.UpdatePostUseCase;
+import toyProject.toyProject01.board.application.port.in.*;
 import toyProject.toyProject01.board.application.port.in.command.GetPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.ResisterPostCommand;
 import toyProject.toyProject01.board.application.port.in.command.UpdatePostCommand;
-import toyProject.toyProject01.board.application.port.out.DeletePostPort;
-import toyProject.toyProject01.board.application.port.out.LoadPostPort;
-import toyProject.toyProject01.board.application.port.out.SavePostPort;
-import toyProject.toyProject01.board.application.port.out.UpdatePostPort;
+import toyProject.toyProject01.board.application.port.out.*;
 import toyProject.toyProject01.board.domain.Category;
 import toyProject.toyProject01.board.domain.Post;
 import toyProject.toyProject01.common.UseCase;
 import toyProject.toyProject01.member.application.port.out.LoadMemberPort;
-import toyProject.toyProject01.member.domain.Member;
 
 import java.util.List;
 
@@ -30,13 +21,15 @@ import java.util.List;
 @Transactional
 @AllArgsConstructor
 @Slf4j
-public class ResisterPostService implements ResisterPostUseCase, LoadPostUseCase, UpdatePostUseCase , DeletePostUseCase {
+public class ResisterPostService implements
+        ResisterPostUseCase, LoadPostUseCase, UpdatePostUseCase , DeletePostUseCase {
 
     private final LoadMemberPort loadMemberPort;
     private final SavePostPort savePostPort;
     private final LoadPostPort loadPostPort;
     private final UpdatePostPort updatePostPort;
     private final DeletePostPort deletePostPort;
+    private final ChangePostStatePort changePostStatePort;
 
     @Override
     public Post registerPost(ResisterPostCommand resisterPostCommand) {
@@ -101,4 +94,10 @@ public class ResisterPostService implements ResisterPostUseCase, LoadPostUseCase
     public void deletePost(Long postId) {
         deletePostPort.deletePost(postId);
     }
+
+    @Override
+    public void softDeletePost(Long postId) {
+        changePostStatePort.delete(postId);
+    }
+
 }


### PR DESCRIPTION
- 게시글을 삭제했을때, 기록이 필요한 경우나 복원이 필요한 경우에 대비해서 실제 데이터를 삭제하지 않고,
  글 상태를 삭제 상태로 변경만 해두도록 변경했습니다.
  
- 게시글을 조회할때도 글 상태가 기본값인 ACTIVE인 상태의 글만 노출되도록 변경하였습니다.
