### PR TITLE
게시판의 댓글 기능 구현

### DIFF
--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import toyProject.toyProject01.board.adapter.in.web.dto.EditCommentDto;
 import toyProject.toyProject01.board.adapter.in.web.dto.RegisterCommentDto;
 import toyProject.toyProject01.board.adapter.in.web.dto.ResponseCommentsDto;
+import toyProject.toyProject01.board.application.port.in.DeleteCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.EditCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.LoadCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.RegisterCommentUseCase;
@@ -27,7 +28,7 @@ public class CommentApiController {
     private final RegisterCommentUseCase registerCommentUseCase;
     private final LoadCommentUseCase loadCommentUseCase;
     private final EditCommentUseCase editCommentUseCase;
-
+    private final DeleteCommentUseCase deleteCommentUseCase;
 
     @PostMapping(value = "/comments")
     public ResponseEntity<ResultDto<String>> RegisterComment(@RequestBody RegisterCommentDto request) {
@@ -68,6 +69,15 @@ public class CommentApiController {
 
         ResultDto<String> result = new ResultDto<>(200, "댓글 수정 완료", "ok");
 
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    @DeleteMapping(value = "/comments/{commentId}")
+    public ResponseEntity<ResultDto<String>> deleteComment(@PathVariable Long commentId) {
+
+        deleteCommentUseCase.softDeleteComment(commentId);
+
+        ResultDto<String> result = new ResultDto<>(200, "댓글 삭제 완료", "ok");
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
@@ -4,15 +4,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import toyProject.toyProject01.board.adapter.in.web.dto.RegisterCommentDto;
+import toyProject.toyProject01.board.adapter.in.web.dto.ResponseCommentsDto;
+import toyProject.toyProject01.board.application.port.in.LoadCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.RegisterCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
 import toyProject.toyProject01.common.ResultDto;
 import toyProject.toyProject01.common.WebAdapter;
+
+import java.util.List;
 
 @WebAdapter
 @RestController
@@ -21,6 +22,7 @@ import toyProject.toyProject01.common.WebAdapter;
 public class CommentApiController {
 
     private final RegisterCommentUseCase registerCommentUseCase;
+    private final LoadCommentUseCase loadCommentUseCase;
 
     @PostMapping(value = "/comments")
     public ResponseEntity<ResultDto<String>> RegisterComment(@RequestBody RegisterCommentDto request) {
@@ -37,4 +39,21 @@ public class CommentApiController {
 
         return new ResponseEntity<>(result, HttpStatus.CREATED);
     }
+
+    @GetMapping(value = "/comments/{postId}")
+    public ResponseEntity<ResultDto<List<ResponseCommentsDto>>> getComments(@PathVariable Long postId) {
+
+        List<ResponseCommentsDto> getComments =
+                loadCommentUseCase.getComments(postId)
+                        .stream()
+                        .map(ResponseMapper::mapToCommentsDto)
+                        .toList();
+
+        ResultDto<List<ResponseCommentsDto>> result =
+                new ResultDto<>(200, "댓글 조회 완료", getComments);
+
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
@@ -1,0 +1,40 @@
+package toyProject.toyProject01.board.adapter.in.web;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import toyProject.toyProject01.board.adapter.in.web.dto.RegisterCommentDto;
+import toyProject.toyProject01.board.application.port.in.RegisterCommentUseCase;
+import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
+import toyProject.toyProject01.common.ResultDto;
+import toyProject.toyProject01.common.WebAdapter;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class CommentApiController {
+
+    private final RegisterCommentUseCase registerCommentUseCase;
+
+    @PostMapping(value = "/comments")
+    public ResponseEntity<ResultDto<String>> RegisterComment(@RequestBody RegisterCommentDto request) {
+        RegisterCommentCommand command = new RegisterCommentCommand(
+                request.getPostId(),
+                request.getNickName(),
+                request.getContent(),
+                request.getParentId()
+        );
+
+        registerCommentUseCase.registerComment(command);
+
+        ResultDto<String> result = new ResultDto<>(200, "저장 완료", "ok");
+
+        return new ResponseEntity<>(result, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
@@ -34,7 +34,7 @@ public class CommentApiController {
     public ResponseEntity<ResultDto<String>> RegisterComment(@RequestBody RegisterCommentDto request) {
         RegisterCommentCommand command = new RegisterCommentCommand(
                 request.getPostId(),
-                request.getNickName(),
+                request.getMemberNo(),
                 request.getContent(),
                 request.getParentId()
         );
@@ -63,7 +63,7 @@ public class CommentApiController {
 
     @PutMapping(value = "/comments")
     public ResponseEntity<ResultDto<String>> editComment(@RequestBody EditCommentDto request) {
-        EditCommentCommand command = new EditCommentCommand(request.getCommentId(), request.getContent());
+        EditCommentCommand command = new EditCommentCommand(request.getCommentId(), request.getContent(), request.getMemberNo());
 
         editCommentUseCase.editComment(command);
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/CommentApiController.java
@@ -5,10 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import toyProject.toyProject01.board.adapter.in.web.dto.EditCommentDto;
 import toyProject.toyProject01.board.adapter.in.web.dto.RegisterCommentDto;
 import toyProject.toyProject01.board.adapter.in.web.dto.ResponseCommentsDto;
+import toyProject.toyProject01.board.application.port.in.EditCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.LoadCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.RegisterCommentUseCase;
+import toyProject.toyProject01.board.application.port.in.command.EditCommentCommand;
 import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
 import toyProject.toyProject01.common.ResultDto;
 import toyProject.toyProject01.common.WebAdapter;
@@ -23,6 +26,8 @@ public class CommentApiController {
 
     private final RegisterCommentUseCase registerCommentUseCase;
     private final LoadCommentUseCase loadCommentUseCase;
+    private final EditCommentUseCase editCommentUseCase;
+
 
     @PostMapping(value = "/comments")
     public ResponseEntity<ResultDto<String>> RegisterComment(@RequestBody RegisterCommentDto request) {
@@ -55,5 +60,14 @@ public class CommentApiController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
+    @PutMapping(value = "/comments")
+    public ResponseEntity<ResultDto<String>> editComment(@RequestBody EditCommentDto request) {
+        EditCommentCommand command = new EditCommentCommand(request.getCommentId(), request.getContent());
 
+        editCommentUseCase.editComment(command);
+
+        ResultDto<String> result = new ResultDto<>(200, "댓글 수정 완료", "ok");
+
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
@@ -7,6 +7,8 @@ import toyProject.toyProject01.board.adapter.in.web.dto.ResponsePostDto;
 import toyProject.toyProject01.board.domain.Comment;
 import toyProject.toyProject01.board.domain.Post;
 
+import java.util.stream.Collectors;
+
 @Component
 public class ResponseMapper {
 
@@ -33,11 +35,20 @@ public class ResponseMapper {
     public static ResponseCommentsDto mapToCommentsDto(Comment comment) {
         return new ResponseCommentsDto(
                 comment.getCommentId(),
-                comment.getParentId(),
                 comment.getMember().getNickName(),
                 comment.getContent(),
                 comment.getCreateTime(),
-                comment.getReplies()
+                comment.getReplies().stream().map(ResponseMapper::mapToReplyDto).collect(Collectors.toList())
+        );
+    }
+
+    public static ResponseCommentsDto.ResponseReplyDto mapToReplyDto(Comment comment) {
+        return new ResponseCommentsDto.ResponseReplyDto(
+                comment.getCommentId(),
+                comment.getParentId(),
+                comment.getMember().getNickName(),
+                comment.getContent(),
+                comment.getCreateTime()
         );
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
@@ -34,7 +34,7 @@ public class ResponseMapper {
         return new ResponseCommentsDto(
                 comment.getCommentId(),
                 comment.getParentId(),
-                comment.getNickName(),
+                comment.getMember().getNickName(),
                 comment.getContent(),
                 comment.getCreateTime(),
                 comment.getReplies()

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/ResponseMapper.java
@@ -1,8 +1,10 @@
 package toyProject.toyProject01.board.adapter.in.web;
 
 import org.springframework.stereotype.Component;
+import toyProject.toyProject01.board.adapter.in.web.dto.ResponseCommentsDto;
 import toyProject.toyProject01.board.adapter.in.web.dto.ResponseListPostDto;
 import toyProject.toyProject01.board.adapter.in.web.dto.ResponsePostDto;
+import toyProject.toyProject01.board.domain.Comment;
 import toyProject.toyProject01.board.domain.Post;
 
 @Component
@@ -25,6 +27,17 @@ public class ResponseMapper {
                 post.getTitle(),
                 post.getMember().getNickName(),
                 post.getCreateDateTime()
+        );
+    }
+
+    public static ResponseCommentsDto mapToCommentsDto(Comment comment) {
+        return new ResponseCommentsDto(
+                comment.getCommentId(),
+                comment.getParentId(),
+                comment.getNickName(),
+                comment.getContent(),
+                comment.getCreateTime(),
+                comment.getReplies()
         );
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/EditCommentDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/EditCommentDto.java
@@ -9,4 +9,5 @@ public class EditCommentDto {
 
     private final Long commentId;
     private final String content;
+    private final Long memberNo;
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/EditCommentDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/EditCommentDto.java
@@ -1,0 +1,12 @@
+package toyProject.toyProject01.board.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EditCommentDto {
+
+    private final Long commentId;
+    private final String content;
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/RegisterCommentDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/RegisterCommentDto.java
@@ -1,0 +1,17 @@
+package toyProject.toyProject01.board.adapter.in.web.dto;
+
+import jakarta.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RegisterCommentDto {
+
+    private final Long postId;
+    private final String nickName;
+    private final String content;
+    @Nullable
+    private Long parentId;
+
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/RegisterCommentDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/RegisterCommentDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class RegisterCommentDto {
 
     private final Long postId;
-    private final String nickName;
+    private final Long memberNo;
     private final String content;
     @Nullable
     private Long parentId;

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResponseCommentsDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResponseCommentsDto.java
@@ -1,0 +1,21 @@
+package toyProject.toyProject01.board.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import toyProject.toyProject01.board.domain.Comment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ResponseCommentsDto {
+
+    private final Long commentId;
+    private final Long parentId;
+    private final String nickName;
+    private final String content;
+    private final LocalDateTime createTime;
+    private final List<Comment> replies;
+
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResponseCommentsDto.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/in/web/dto/ResponseCommentsDto.java
@@ -5,17 +5,33 @@ import lombok.Getter;
 import toyProject.toyProject01.board.domain.Comment;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 public class ResponseCommentsDto {
 
     private final Long commentId;
-    private final Long parentId;
     private final String nickName;
     private final String content;
     private final LocalDateTime createTime;
-    private final List<Comment> replies;
+    private final List<ResponseReplyDto> replies;
 
+    public ResponseCommentsDto(Long commentId, String nickName, String content, LocalDateTime createTime, List<ResponseReplyDto> replies) {
+        this.commentId = commentId;
+        this.nickName = nickName;
+        this.content = content;
+        this.createTime = createTime;
+        this.replies = replies;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ResponseReplyDto {
+        private final Long commentId;
+        private final Long parentId;
+        private final String nickName;
+        private final String content;
+        private final LocalDateTime createTime;
+    }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 @PersistenceAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class CommentPersistenceAdapter implements RegisterCommentPort {
+public class CommentPersistenceAdapter implements RegisterCommentPort, LoadCommentsPort {
 
     private final SpringDataCommentRepository repository;
 
@@ -31,5 +31,13 @@ public class CommentPersistenceAdapter implements RegisterCommentPort {
         CommentEntity repliesEntity = PersistenceMapper.mapToCommentEntityForReplies(comment, parentEntity);
 
         repository.save(repliesEntity);
+    }
+
+    @Override
+    public List<Comment> getComments(Long postId) {
+        return repository.getComments(postId, CommentEntity.CommentState.ACTIVE)
+                .stream()
+                .map(PersistenceMapper::mapToCommentDomainForGetComments)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -1,0 +1,35 @@
+package toyProject.toyProject01.board.adapter.out.persistence;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import toyProject.toyProject01.board.adapter.out.persistence.entity.CommentEntity;
+import toyProject.toyProject01.board.application.port.out.LoadCommentsPort;
+import toyProject.toyProject01.board.application.port.out.RegisterCommentPort;
+import toyProject.toyProject01.board.domain.Comment;
+import toyProject.toyProject01.common.PersistenceAdapter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class CommentPersistenceAdapter implements RegisterCommentPort {
+
+    private final SpringDataCommentRepository repository;
+
+    @Override
+    public void saveParentComment(Comment comment) {
+        CommentEntity parentComment = PersistenceMapper.mapToCommentEntityForParent(comment);
+        repository.save(parentComment);
+    }
+
+    @Override
+    public void saveRepliesComment(Comment comment) {
+        CommentEntity parentEntity = repository.findById(comment.getParentId()).orElseThrow();
+
+        CommentEntity repliesEntity = PersistenceMapper.mapToCommentEntityForReplies(comment, parentEntity);
+
+        repository.save(repliesEntity);
+    }
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -5,16 +5,18 @@ import lombok.extern.slf4j.Slf4j;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.CommentEntity;
 import toyProject.toyProject01.board.application.port.out.LoadCommentsPort;
 import toyProject.toyProject01.board.application.port.out.RegisterCommentPort;
+import toyProject.toyProject01.board.application.port.out.UpdateCommentPort;
 import toyProject.toyProject01.board.domain.Comment;
 import toyProject.toyProject01.common.PersistenceAdapter;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class CommentPersistenceAdapter implements RegisterCommentPort, LoadCommentsPort {
+public class CommentPersistenceAdapter implements RegisterCommentPort, LoadCommentsPort, UpdateCommentPort {
 
     private final SpringDataCommentRepository repository;
 
@@ -39,5 +41,12 @@ public class CommentPersistenceAdapter implements RegisterCommentPort, LoadComme
                 .stream()
                 .map(PersistenceMapper::mapToCommentDomainForGetComments)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void updateToEditComment(Comment editComment) {
+        CommentEntity savedComment = repository.findById(editComment.getCommentId()).orElseThrow();
+
+        savedComment.updateToEditComment(editComment.getContent());
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -10,7 +10,6 @@ import toyProject.toyProject01.board.domain.Comment;
 import toyProject.toyProject01.common.PersistenceAdapter;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @PersistenceAdapter
@@ -37,7 +36,7 @@ public class CommentPersistenceAdapter implements RegisterCommentPort, LoadComme
 
     @Override
     public List<Comment> getComments(Long postId) {
-        return repository.getComments(postId, CommentEntity.CommentState.ACTIVE)
+        return repository.getComments(postId, CommentEntity.CommentState.ACTIVE, CommentEntity.CommentState.DELETE_PARENT)
                 .stream()
                 .map(PersistenceMapper::mapToCommentDomainForGetComments)
                 .collect(Collectors.toList());
@@ -48,5 +47,15 @@ public class CommentPersistenceAdapter implements RegisterCommentPort, LoadComme
         CommentEntity savedComment = repository.findById(editComment.getCommentId()).orElseThrow();
 
         savedComment.updateToEditComment(editComment.getContent());
+    }
+
+    @Override
+    public void updateToDeleteState(Long commentId) {
+        CommentEntity savedComment = repository.findById(commentId).orElseThrow();
+        if (savedComment.getParent() == null) {
+            savedComment.updateToDelete_Parent_State();
+        } else {
+            savedComment.updateToDelete_State();
+        }
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -27,10 +27,7 @@ public class CommentPersistenceAdapter implements RegisterCommentPort, LoadComme
 
     @Override
     public void saveRepliesComment(Comment comment) {
-        CommentEntity parentEntity = repository.findById(comment.getParentId()).orElseThrow();
-
-        CommentEntity repliesEntity = PersistenceMapper.mapToCommentEntityForReplies(comment, parentEntity);
-
+        CommentEntity repliesEntity = PersistenceMapper.mapToCommentEntityForReplies(comment, comment.getParentId());
         repository.save(repliesEntity);
     }
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -80,12 +80,12 @@ public class PersistenceMapper {
         );
     }
 
-    public static CommentEntity mapToCommentEntityForReplies(Comment comment, CommentEntity parent) {
+    public static CommentEntity mapToCommentEntityForReplies(Comment comment, Long parentId) {
         return new CommentEntity(
                 comment.getPostId(),
                 new MemberJpaEntity(comment.getMember().getMemberNo()),
                 comment.getContent(),
-                parent
+                parentId
         );
     }
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -89,4 +89,15 @@ public class PersistenceMapper {
         );
     }
 
+    public static Comment mapToCommentDomainForGetComments(CommentEntity commentEntity) {
+        Long parentId = (commentEntity.getParent() != null) ? commentEntity.getParent().getCommentId() : null;
+
+        return Comment.mapToCommentForGetComments(
+                commentEntity.getCommentId(),
+                commentEntity.getMemberNickName(),
+                commentEntity.getContent(),
+                commentEntity.getCreateTime(),
+                parentId
+        );
+    }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -75,7 +75,7 @@ public class PersistenceMapper {
     public static CommentEntity mapToCommentEntityForParent(Comment comment) {
         return new CommentEntity(
                 comment.getPostId(),
-                comment.getNickName(),
+                new MemberJpaEntity(comment.getMember().getMemberNo()),
                 comment.getContent()
         );
     }
@@ -83,7 +83,7 @@ public class PersistenceMapper {
     public static CommentEntity mapToCommentEntityForReplies(Comment comment, CommentEntity parent) {
         return new CommentEntity(
                 comment.getPostId(),
-                comment.getNickName(),
+                new MemberJpaEntity(comment.getMember().getMemberNo()),
                 comment.getContent(),
                 parent
         );
@@ -94,11 +94,10 @@ public class PersistenceMapper {
 
         if (commentEntity.isDeletedParent(commentEntity.getState())) {
             return Comment.mapToDeletedParentComment(commentEntity.getCommentId());
-
         } else {
             return Comment.mapToCommentForGetComments(
                     commentEntity.getCommentId(),
-                    commentEntity.getMemberNickName(),
+                    commentEntity.getMember().getNickName(),
                     commentEntity.getContent(),
                     commentEntity.getCreateTime(),
                     parentId

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -92,12 +92,17 @@ public class PersistenceMapper {
     public static Comment mapToCommentDomainForGetComments(CommentEntity commentEntity) {
         Long parentId = (commentEntity.getParent() != null) ? commentEntity.getParent().getCommentId() : null;
 
-        return Comment.mapToCommentForGetComments(
-                commentEntity.getCommentId(),
-                commentEntity.getMemberNickName(),
-                commentEntity.getContent(),
-                commentEntity.getCreateTime(),
-                parentId
-        );
+        if (commentEntity.isDeletedParent(commentEntity.getState())) {
+            return Comment.mapToDeletedParentComment(commentEntity.getCommentId());
+
+        } else {
+            return Comment.mapToCommentForGetComments(
+                    commentEntity.getCommentId(),
+                    commentEntity.getMemberNickName(),
+                    commentEntity.getContent(),
+                    commentEntity.getCreateTime(),
+                    parentId
+            );
+        }
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/PersistenceMapper.java
@@ -4,11 +4,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.CategoryJpaEntity;
+import toyProject.toyProject01.board.adapter.out.persistence.entity.CommentEntity;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.PostJpaEntity;
 import toyProject.toyProject01.board.domain.Category;
+import toyProject.toyProject01.board.domain.Comment;
 import toyProject.toyProject01.board.domain.Post;
 import toyProject.toyProject01.member.adapter.out.persistence.MemberJpaEntity;
-import toyProject.toyProject01.member.adapter.out.persistence.MemberMapper;
 
 @Component
 @RequiredArgsConstructor
@@ -68,6 +69,23 @@ public class PersistenceMapper {
         return new Category(
                 categoryJpaEntity.getCategoryId(),
                 categoryJpaEntity.getType()
+        );
+    }
+
+    public static CommentEntity mapToCommentEntityForParent(Comment comment) {
+        return new CommentEntity(
+                comment.getPostId(),
+                comment.getNickName(),
+                comment.getContent()
+        );
+    }
+
+    public static CommentEntity mapToCommentEntityForReplies(Comment comment, CommentEntity parent) {
+        return new CommentEntity(
+                comment.getPostId(),
+                comment.getNickName(),
+                comment.getContent(),
+                parent
         );
     }
 

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataCommentRepository.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataCommentRepository.java
@@ -10,7 +10,8 @@ import java.util.List;
 public interface SpringDataCommentRepository extends JpaRepository<CommentEntity, Long> {
 
     @Query("SELECT c from CommentEntity " +
-            "c left JOIN FETCH c.replies " +
+            "c LEFT JOIN FETCH c.replies " +
+            "LEFT JOIN FETCH c.member " +
             "WHERE c.postId = :postId AND (c.state = :defaultState OR c.state = :deletedParentState) " +
             "ORDER BY c.createTime ASC, c.commentId ASC")
     List<CommentEntity> getComments(

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataCommentRepository.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataCommentRepository.java
@@ -1,0 +1,8 @@
+package toyProject.toyProject01.board.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import toyProject.toyProject01.board.adapter.out.persistence.entity.CommentEntity;
+
+public interface SpringDataCommentRepository extends JpaRepository<CommentEntity, Long> {
+
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataCommentRepository.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataCommentRepository.java
@@ -1,8 +1,17 @@
 package toyProject.toyProject01.board.adapter.out.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import toyProject.toyProject01.board.adapter.out.persistence.entity.CommentEntity;
+
+import java.util.List;
 
 public interface SpringDataCommentRepository extends JpaRepository<CommentEntity, Long> {
 
+    @Query("SELECT c from CommentEntity " +
+            "c left JOIN FETCH c.replies " +
+            "WHERE c.postId = :postId AND c.state = :state " +
+            "ORDER BY c.createTime ASC, c.commentId ASC")
+    List<CommentEntity> getComments(@Param("postId")Long postId, @Param("state") CommentEntity.CommentState state);
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataCommentRepository.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/SpringDataCommentRepository.java
@@ -11,7 +11,10 @@ public interface SpringDataCommentRepository extends JpaRepository<CommentEntity
 
     @Query("SELECT c from CommentEntity " +
             "c left JOIN FETCH c.replies " +
-            "WHERE c.postId = :postId AND c.state = :state " +
+            "WHERE c.postId = :postId AND (c.state = :defaultState OR c.state = :deletedParentState) " +
             "ORDER BY c.createTime ASC, c.commentId ASC")
-    List<CommentEntity> getComments(@Param("postId")Long postId, @Param("state") CommentEntity.CommentState state);
+    List<CommentEntity> getComments(
+            @Param("postId")Long postId,
+            @Param("defaultState") CommentEntity.CommentState state,
+            @Param("deletedParentState")CommentEntity.CommentState deletedParent);
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
@@ -50,9 +50,11 @@ public class CommentEntity {
     public enum CommentState {
         ACTIVE,
         DELETE,
+        DELETE_PARENT,
         HIDE,
         REVIEW
     }
+
 
     public void updateToEditComment(String content) {
         this.content = content;
@@ -69,5 +71,17 @@ public class CommentEntity {
         this.memberNickName = memberNickName;
         this.content = content;
         this.parent = parent;
+    }
+
+     public boolean isDeletedParent(CommentState state) {
+        return state.equals(CommentState.DELETE_PARENT);
+    }
+
+    public void updateToDelete_Parent_State() {
+        this.state = CommentState.DELETE_PARENT;
+    }
+
+    public void updateToDelete_State() {
+        this.state = CommentState.DELETE;
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
@@ -1,0 +1,69 @@
+package toyProject.toyProject01.board.adapter.out.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Table(name = "comment")
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long commentId;
+
+    @Column(name = "postId")
+    private Long postId;
+
+    @Column(name = "nickName")
+    private String memberNickName;
+
+    @Column(name = "content")
+    private String content;
+
+    @CreatedDate
+    @Column(name = "createTime")
+    private LocalDateTime createTime;
+
+    @Enumerated(EnumType.STRING)
+    private CommentState state = CommentState.ACTIVE;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private CommentEntity parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<CommentEntity> replies = new ArrayList<>();
+
+    public enum CommentState {
+        ACTIVE,
+        DELETE,
+        HIDE,
+        REVIEW
+    }
+
+    public CommentEntity(Long postId, String memberNickName, String content) {
+        this.postId = postId;
+        this.memberNickName = memberNickName;
+        this.content = content;
+    }
+
+    public CommentEntity(Long postId, String memberNickName, String content, CommentEntity parent) {
+        this.postId = postId;
+        this.memberNickName = memberNickName;
+        this.content = content;
+        this.parent = parent;
+    }
+}

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
@@ -54,6 +54,10 @@ public class CommentEntity {
         REVIEW
     }
 
+    public void updateToEditComment(String content) {
+        this.content = content;
+    }
+
     public CommentEntity(Long postId, String memberNickName, String content) {
         this.postId = postId;
         this.memberNickName = memberNickName;

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import toyProject.toyProject01.member.adapter.out.persistence.MemberJpaEntity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -21,14 +22,15 @@ public class CommentEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
+    @Column(name = "commentId")
     private Long commentId;
 
     @Column(name = "postId")
     private Long postId;
 
-    @Column(name = "nickName")
-    private String memberNickName;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberNo")
+    private MemberJpaEntity member;
 
     @Column(name = "content")
     private String content;
@@ -60,15 +62,15 @@ public class CommentEntity {
         this.content = content;
     }
 
-    public CommentEntity(Long postId, String memberNickName, String content) {
+    public CommentEntity(Long postId, MemberJpaEntity member, String content) {
         this.postId = postId;
-        this.memberNickName = memberNickName;
+        this.member = member;
         this.content = content;
     }
 
-    public CommentEntity(Long postId, String memberNickName, String content, CommentEntity parent) {
+    public CommentEntity(Long postId, MemberJpaEntity member, String content, CommentEntity parent) {
         this.postId = postId;
-        this.memberNickName = memberNickName;
+        this.member = member;
         this.content = content;
         this.parent = parent;
     }

--- a/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
+++ b/src/main/java/toyProject/toyProject01/board/adapter/out/persistence/entity/CommentEntity.java
@@ -68,11 +68,15 @@ public class CommentEntity {
         this.content = content;
     }
 
-    public CommentEntity(Long postId, MemberJpaEntity member, String content, CommentEntity parent) {
+    public CommentEntity(Long postId, MemberJpaEntity member, String content, Long parentId) {
         this.postId = postId;
         this.member = member;
         this.content = content;
-        this.parent = parent;
+        this.parent = new CommentEntity(parentId);
+    }
+
+    public CommentEntity(Long parentId) {
+        this.commentId = parentId;
     }
 
      public boolean isDeletedParent(CommentState state) {

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/DeleteCommentUseCase.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/DeleteCommentUseCase.java
@@ -1,0 +1,6 @@
+package toyProject.toyProject01.board.application.port.in;
+
+public interface DeleteCommentUseCase {
+
+    void softDeleteComment(Long commentId);
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/EditCommentUseCase.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/EditCommentUseCase.java
@@ -1,0 +1,8 @@
+package toyProject.toyProject01.board.application.port.in;
+
+import toyProject.toyProject01.board.application.port.in.command.EditCommentCommand;
+
+public interface EditCommentUseCase {
+
+    void editComment(EditCommentCommand editCommand);
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/LoadCommentUseCase.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/LoadCommentUseCase.java
@@ -1,0 +1,9 @@
+package toyProject.toyProject01.board.application.port.in;
+
+import toyProject.toyProject01.board.domain.Comment;
+import java.util.List;
+
+public interface LoadCommentUseCase {
+
+    List<Comment> getComments(Long postId);
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/RegisterCommentUseCase.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/RegisterCommentUseCase.java
@@ -1,0 +1,9 @@
+package toyProject.toyProject01.board.application.port.in;
+
+import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
+
+public interface RegisterCommentUseCase {
+
+    void registerComment(RegisterCommentCommand registerComment);
+
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/command/EditCommentCommand.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/command/EditCommentCommand.java
@@ -12,10 +12,13 @@ public class EditCommentCommand extends SelfValidating<EditCommentCommand> {
     private final Long commentId;
     @NotBlank
     private final String content;
+    @NotNull
+    private final Long memberNo;
 
-    public EditCommentCommand(Long commentId, String content) {
+    public EditCommentCommand(Long commentId, String content, Long memberNo) {
         this.commentId = commentId;
         this.content = content;
+        this.memberNo = memberNo;
 
         this.validateSelf();
     }

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/command/EditCommentCommand.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/command/EditCommentCommand.java
@@ -1,0 +1,22 @@
+package toyProject.toyProject01.board.application.port.in.command;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import toyProject.toyProject01.common.SelfValidating;
+
+@Getter
+public class EditCommentCommand extends SelfValidating<EditCommentCommand> {
+
+    @NotNull
+    private final Long commentId;
+    @NotBlank
+    private final String content;
+
+    public EditCommentCommand(Long commentId, String content) {
+        this.commentId = commentId;
+        this.content = content;
+
+        this.validateSelf();
+    }
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/command/RegisterCommentCommand.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/command/RegisterCommentCommand.java
@@ -1,0 +1,31 @@
+package toyProject.toyProject01.board.application.port.in.command;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import toyProject.toyProject01.common.SelfValidating;
+
+@Getter
+public class RegisterCommentCommand extends SelfValidating<RegisterCommentCommand> {
+
+    @NotNull
+    private final Long postId;
+    @NotBlank
+    private final String nickName;
+    @NotBlank
+    private final String content;
+    @Nullable
+    private final Long parentId;
+
+    public RegisterCommentCommand(Long postId, String nickName, String content, @Nullable Long parentId) {
+        this.postId = postId;
+        this.nickName = nickName;
+        this.content = content;
+        this.parentId = parentId;
+
+        this.validateSelf();
+    }
+
+}
+

--- a/src/main/java/toyProject/toyProject01/board/application/port/in/command/RegisterCommentCommand.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/in/command/RegisterCommentCommand.java
@@ -11,16 +11,16 @@ public class RegisterCommentCommand extends SelfValidating<RegisterCommentComman
 
     @NotNull
     private final Long postId;
-    @NotBlank
-    private final String nickName;
+    @NotNull
+    private final Long memberNo;
     @NotBlank
     private final String content;
     @Nullable
     private final Long parentId;
 
-    public RegisterCommentCommand(Long postId, String nickName, String content, @Nullable Long parentId) {
+    public RegisterCommentCommand(Long postId, Long memberNo, String content, @Nullable Long parentId) {
         this.postId = postId;
-        this.nickName = nickName;
+        this.memberNo = memberNo;
         this.content = content;
         this.parentId = parentId;
 

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/LoadCommentsPort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/LoadCommentsPort.java
@@ -1,0 +1,10 @@
+package toyProject.toyProject01.board.application.port.out;
+
+import toyProject.toyProject01.board.domain.Comment;
+
+import java.util.List;
+
+public interface LoadCommentsPort {
+
+    List<Comment> getComments(Long postId);
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/RegisterCommentPort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/RegisterCommentPort.java
@@ -1,0 +1,10 @@
+package toyProject.toyProject01.board.application.port.out;
+
+import toyProject.toyProject01.board.domain.Comment;
+
+public interface RegisterCommentPort {
+
+    void saveParentComment(Comment comment);
+
+    void saveRepliesComment(Comment comment);
+}

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/UpdateCommentPort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/UpdateCommentPort.java
@@ -5,4 +5,6 @@ import toyProject.toyProject01.board.domain.Comment;
 public interface UpdateCommentPort {
 
     void updateToEditComment(Comment editComment);
+
+    void updateToDeleteState(Long commentId);
 }

--- a/src/main/java/toyProject/toyProject01/board/application/port/out/UpdateCommentPort.java
+++ b/src/main/java/toyProject/toyProject01/board/application/port/out/UpdateCommentPort.java
@@ -1,0 +1,8 @@
+package toyProject.toyProject01.board.application.port.out;
+
+import toyProject.toyProject01.board.domain.Comment;
+
+public interface UpdateCommentPort {
+
+    void updateToEditComment(Comment editComment);
+}

--- a/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
@@ -3,11 +3,14 @@ package toyProject.toyProject01.board.application.service;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+import toyProject.toyProject01.board.application.port.in.EditCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.LoadCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.RegisterCommentUseCase;
+import toyProject.toyProject01.board.application.port.in.command.EditCommentCommand;
 import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
 import toyProject.toyProject01.board.application.port.out.LoadCommentsPort;
 import toyProject.toyProject01.board.application.port.out.RegisterCommentPort;
+import toyProject.toyProject01.board.application.port.out.UpdateCommentPort;
 import toyProject.toyProject01.board.domain.Comment;
 import toyProject.toyProject01.common.UseCase;
 
@@ -18,10 +21,11 @@ import java.util.List;
 @Transactional
 @AllArgsConstructor
 @Slf4j
-public class CommentService implements RegisterCommentUseCase, LoadCommentUseCase {
+public class CommentService implements RegisterCommentUseCase, LoadCommentUseCase, EditCommentUseCase {
 
     private final RegisterCommentPort registerPort;
     private final LoadCommentsPort loadPort;
+    private final UpdateCommentPort updatePort;
 
     @Override
     public void registerComment(RegisterCommentCommand registerCommand) {
@@ -63,6 +67,13 @@ public class CommentService implements RegisterCommentUseCase, LoadCommentUseCas
         }
 
         return resultComments;
+    }
+
+    @Override
+    public void editComment(EditCommentCommand editCommand) {
+        Comment editComment = Comment.mapToCommentForEdit(editCommand.getCommentId(), editCommand.getContent());
+
+        updatePort.updateToEditComment(editComment);
     }
 }
 

--- a/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
@@ -29,7 +29,7 @@ public class CommentService implements RegisterCommentUseCase, LoadCommentUseCas
     public void registerComment(RegisterCommentCommand registerCommand) {
         Comment comment = Comment.mapToCommentForRegister(
                 registerCommand.getPostId(),
-                registerCommand.getNickName(),
+                registerCommand.getMemberNo(),
                 registerCommand.getContent(),
                 registerCommand.getParentId()
         );

--- a/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
@@ -3,9 +3,7 @@ package toyProject.toyProject01.board.application.service;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
-import toyProject.toyProject01.board.application.port.in.EditCommentUseCase;
-import toyProject.toyProject01.board.application.port.in.LoadCommentUseCase;
-import toyProject.toyProject01.board.application.port.in.RegisterCommentUseCase;
+import toyProject.toyProject01.board.application.port.in.*;
 import toyProject.toyProject01.board.application.port.in.command.EditCommentCommand;
 import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
 import toyProject.toyProject01.board.application.port.out.LoadCommentsPort;
@@ -21,7 +19,7 @@ import java.util.List;
 @Transactional
 @AllArgsConstructor
 @Slf4j
-public class CommentService implements RegisterCommentUseCase, LoadCommentUseCase, EditCommentUseCase {
+public class CommentService implements RegisterCommentUseCase, LoadCommentUseCase, EditCommentUseCase, DeleteCommentUseCase {
 
     private final RegisterCommentPort registerPort;
     private final LoadCommentsPort loadPort;
@@ -65,7 +63,6 @@ public class CommentService implements RegisterCommentUseCase, LoadCommentUseCas
                 }
             }
         }
-
         return resultComments;
     }
 
@@ -74,6 +71,11 @@ public class CommentService implements RegisterCommentUseCase, LoadCommentUseCas
         Comment editComment = Comment.mapToCommentForEdit(editCommand.getCommentId(), editCommand.getContent());
 
         updatePort.updateToEditComment(editComment);
+    }
+
+    @Override
+    public void softDeleteComment(Long commentId) {
+        updatePort.updateToDeleteState(commentId);
     }
 }
 

--- a/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
@@ -3,19 +3,25 @@ package toyProject.toyProject01.board.application.service;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+import toyProject.toyProject01.board.application.port.in.LoadCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.RegisterCommentUseCase;
 import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
+import toyProject.toyProject01.board.application.port.out.LoadCommentsPort;
 import toyProject.toyProject01.board.application.port.out.RegisterCommentPort;
 import toyProject.toyProject01.board.domain.Comment;
 import toyProject.toyProject01.common.UseCase;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @UseCase
 @Transactional
 @AllArgsConstructor
 @Slf4j
-public class CommentService implements RegisterCommentUseCase {
+public class CommentService implements RegisterCommentUseCase, LoadCommentUseCase {
 
     private final RegisterCommentPort registerPort;
+    private final LoadCommentsPort loadPort;
 
     @Override
     public void registerComment(RegisterCommentCommand registerCommand) {
@@ -33,5 +39,30 @@ public class CommentService implements RegisterCommentUseCase {
         }
     }
 
+    @Override
+    public List<Comment> getComments(Long postId) {
+        List<Comment> getComments = loadPort.getComments(postId);
+
+        return sortComments(getComments);
+    }
+
+    private List<Comment> sortComments(List<Comment> comments) {
+        List<Comment> resultComments = new ArrayList<>();
+        //부모-자식 댓글 계층 정리
+        for (Comment comment : comments) {
+            if (comment.getParentId() == null) {
+                resultComments.add(comment);
+            } else {
+                for (Comment parentComment : resultComments) {
+                    if (comment.getParentId().equals(parentComment.getCommentId())) {
+                        parentComment.getReplies().add(comment);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return resultComments;
+    }
 }
 

--- a/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
+++ b/src/main/java/toyProject/toyProject01/board/application/service/CommentService.java
@@ -1,0 +1,37 @@
+package toyProject.toyProject01.board.application.service;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+import toyProject.toyProject01.board.application.port.in.RegisterCommentUseCase;
+import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
+import toyProject.toyProject01.board.application.port.out.RegisterCommentPort;
+import toyProject.toyProject01.board.domain.Comment;
+import toyProject.toyProject01.common.UseCase;
+
+@UseCase
+@Transactional
+@AllArgsConstructor
+@Slf4j
+public class CommentService implements RegisterCommentUseCase {
+
+    private final RegisterCommentPort registerPort;
+
+    @Override
+    public void registerComment(RegisterCommentCommand registerCommand) {
+        Comment comment = Comment.mapToCommentForRegister(
+                registerCommand.getPostId(),
+                registerCommand.getNickName(),
+                registerCommand.getContent(),
+                registerCommand.getParentId()
+        );
+
+        if(comment.getParentId() == null) {
+            registerPort.saveParentComment(comment);
+        } else {
+            registerPort.saveRepliesComment(comment);
+        }
+    }
+
+}
+

--- a/src/main/java/toyProject/toyProject01/board/domain/Comment.java
+++ b/src/main/java/toyProject/toyProject01/board/domain/Comment.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Value;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -22,4 +23,13 @@ public class Comment {
         return new Comment(null, postId, nickName, content, null, parentId, null);
     }
 
+    public static Comment mapToCommentForGetComments (
+            Long commentId,
+            String nickName,
+            String content,
+            LocalDateTime createTime,
+            Long parentId
+    ) {
+        return new Comment(commentId, null, nickName, content, createTime, parentId, new ArrayList<>());
+    }
 }

--- a/src/main/java/toyProject/toyProject01/board/domain/Comment.java
+++ b/src/main/java/toyProject/toyProject01/board/domain/Comment.java
@@ -36,4 +36,8 @@ public class Comment {
     public static Comment mapToCommentForEdit(Long commentId, String content) {
         return new Comment(commentId, null, null, content, null, null, null);
     }
+
+    public static Comment mapToDeletedParentComment(Long commentId) {
+        return new Comment(commentId, null, "(삭제)", "삭제된 내용입니다.", null, null, new ArrayList<>());
+    }
 }

--- a/src/main/java/toyProject/toyProject01/board/domain/Comment.java
+++ b/src/main/java/toyProject/toyProject01/board/domain/Comment.java
@@ -32,4 +32,8 @@ public class Comment {
     ) {
         return new Comment(commentId, null, nickName, content, createTime, parentId, new ArrayList<>());
     }
+
+    public static Comment mapToCommentForEdit(Long commentId, String content) {
+        return new Comment(commentId, null, null, content, null, null, null);
+    }
 }

--- a/src/main/java/toyProject/toyProject01/board/domain/Comment.java
+++ b/src/main/java/toyProject/toyProject01/board/domain/Comment.java
@@ -1,5 +1,6 @@
 package toyProject.toyProject01.board.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Value;
 
@@ -13,14 +14,21 @@ public class Comment {
 
     private Long commentId;
     private Long postId;
-    private String nickName;
+    private CommentMember member;
     private String content;
     private LocalDateTime createTime;
     private Long parentId;
     private List<Comment> replies;
 
-    public static Comment mapToCommentForRegister(Long postId, String nickName, String content, Long parentId) {
-        return new Comment(null, postId, nickName, content, null, parentId, null);
+    @Getter
+    @AllArgsConstructor
+    public static class CommentMember {
+        private final Long memberNo;
+        private final String nickName;
+    }
+
+    public static Comment mapToCommentForRegister(Long postId, Long memberNo, String content, Long parentId) {
+        return new Comment(null, postId, new CommentMember(memberNo, null), content, null, parentId, null);
     }
 
     public static Comment mapToCommentForGetComments (
@@ -30,14 +38,14 @@ public class Comment {
             LocalDateTime createTime,
             Long parentId
     ) {
-        return new Comment(commentId, null, nickName, content, createTime, parentId, new ArrayList<>());
+        return new Comment(commentId, null, new CommentMember(null, nickName), content, createTime, parentId, new ArrayList<>());
     }
 
     public static Comment mapToCommentForEdit(Long commentId, String content) {
-        return new Comment(commentId, null, null, content, null, null, null);
+        return new Comment(commentId, null, new CommentMember(null,null), content, null, null, null);
     }
 
     public static Comment mapToDeletedParentComment(Long commentId) {
-        return new Comment(commentId, null, "(삭제)", "삭제된 내용입니다.", null, null, new ArrayList<>());
+        return new Comment(commentId, null, new CommentMember(null, null), "삭제된 내용입니다.", null, null, new ArrayList<>());
     }
 }

--- a/src/main/java/toyProject/toyProject01/board/domain/Comment.java
+++ b/src/main/java/toyProject/toyProject01/board/domain/Comment.java
@@ -1,0 +1,25 @@
+package toyProject.toyProject01.board.domain;
+
+import lombok.Getter;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Value
+public class Comment {
+
+    private Long commentId;
+    private Long postId;
+    private String nickName;
+    private String content;
+    private LocalDateTime createTime;
+    private Long parentId;
+    private List<Comment> replies;
+
+    public static Comment mapToCommentForRegister(Long postId, String nickName, String content, Long parentId) {
+        return new Comment(null, postId, nickName, content, null, parentId, null);
+    }
+
+}

--- a/src/test/java/toyProject/toyProject01/board/application/service/CommentServiceTest.java
+++ b/src/test/java/toyProject/toyProject01/board/application/service/CommentServiceTest.java
@@ -22,7 +22,7 @@ class CommentServiceTest {
     void registerParentComment() {
         //given
         RegisterCommentCommand registerCommentCommand =
-                new RegisterCommentCommand(17L, "댓글", "test1", null);
+                new RegisterCommentCommand(1L, 1L, "부모댓글2", null);
 
         //when
         commentService.registerComment(registerCommentCommand);
@@ -36,7 +36,7 @@ class CommentServiceTest {
     void registerRepliesComment() {
         //given
         RegisterCommentCommand registerCommentCommand =
-                new RegisterCommentCommand(17L, "대댓글", "대댓글", 1L);
+                new RegisterCommentCommand(1L, 1L, "대댓글1", 4L);
 
         //when
         commentService.registerComment(registerCommentCommand);
@@ -44,5 +44,6 @@ class CommentServiceTest {
         //then
 
     }
+
 
 }

--- a/src/test/java/toyProject/toyProject01/board/application/service/CommentServiceTest.java
+++ b/src/test/java/toyProject/toyProject01/board/application/service/CommentServiceTest.java
@@ -1,0 +1,48 @@
+package toyProject.toyProject01.board.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import toyProject.toyProject01.board.application.port.in.command.RegisterCommentCommand;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+class CommentServiceTest {
+
+    @Autowired
+    CommentService commentService;
+
+    @Test
+    @DisplayName("부모 댓글 저장")
+    void registerParentComment() {
+        //given
+        RegisterCommentCommand registerCommentCommand =
+                new RegisterCommentCommand(17L, "댓글", "test1", null);
+
+        //when
+        commentService.registerComment(registerCommentCommand);
+
+        //then
+
+    }
+
+    @Test
+    @DisplayName("대댓글 저장")
+    void registerRepliesComment() {
+        //given
+        RegisterCommentCommand registerCommentCommand =
+                new RegisterCommentCommand(17L, "대댓글", "대댓글", 1L);
+
+        //when
+        commentService.registerComment(registerCommentCommand);
+
+        //then
+
+    }
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -18,6 +18,6 @@ mybatis.mapper-locations=classpath:mapper/**/*.xml
 #JPA
 #JPA
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto= create
+spring.jpa.hibernate.ddl-auto= update
 
 


### PR DESCRIPTION
- 게시판에 댓글기능을 추가하기 위해 댓글의 저장, 조회, 삭제, 수정기능을 구현했습니다.

- 댓글 등록 기능
- 부모 댓글을 저장할때와, 대댓글을 저장할때의 조건이 다르기 때문에 저장 로직을 분류하여 구현했습니다.

- 댓글 조회기능
- 댓글을 조회할때 부모댓글과 해당하는 대댓글들의 계층을 분류하여 응답을 해야하기 때문에 쿼리작성과 정렬작업을 통해 구현했습니다.

- 댓글 삭제기능
- 부모 댓글 삭제시, 자식댓글은 그대로 보존하여 응답하기위해 삭제 로직을 분류하였고, 이를 반영하기 위해 조회를 할때 삭제관련 로직을 추가했습니다.

- 댓글 수정기능
- 댓글 수정을 할때는 유저가 댓글의 내용만 수정할 수 있도록 구현했습니다. 